### PR TITLE
[JD-153]Refactor: 삭제된 다이어리는 채팅방에서 채팅 내역만 보여주기

### DIFF
--- a/src/hooks/useChatting.ts
+++ b/src/hooks/useChatting.ts
@@ -41,7 +41,7 @@ export const useFetchChatHistory = (size: number, chatRoomId: number) => {
       }
     },
     select: (r) => {
-      return r.pages.flatMap((r) => r.data.data.chatMessageList);
+      return r.pages.flatMap((r) => r.data.data);
     },
   });
   return { data, isLoading, ...rest };

--- a/src/pages/ChatPage/ChatPageMain/ChatPageChat/index.tsx
+++ b/src/pages/ChatPage/ChatPageMain/ChatPageChat/index.tsx
@@ -66,7 +66,8 @@ const ChatPageChat: React.FC = () => {
 
   useEffect(() => {
     if (messageHistory) {
-      const sortedMessage = [...messageHistory].sort(
+      const messageList = messageHistory.flatMap((r) => r.chatMessageList);
+      const sortedMessage = [...messageList].sort(
         (a: MessageListType, b: MessageListType) =>
           new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
       );
@@ -209,14 +210,20 @@ const ChatPageChat: React.FC = () => {
           ))}
         <div ref={messageEndRef}></div>
       </ChatMessagesContainer>
-      <ChatFooterForm />
+      <ChatFooterForm
+        isDiaryDeleted={messageHistory && messageHistory[0].isDiaryDeleted}
+      />
     </ChatContainer>
   );
 };
 
 export default ChatPageChat;
 
-const ChatFooterForm: React.FC = () => {
+interface ChatFooterFormProps {
+  isDiaryDeleted: boolean;
+}
+
+const ChatFooterForm: React.FC<ChatFooterFormProps> = ({ isDiaryDeleted }) => {
   const [message, setMessage] = useState("");
   const { userData } = useLoginUser();
   const { chatRoomId, stompClient } = useChattingStore((state) => state);
@@ -245,6 +252,7 @@ const ChatFooterForm: React.FC = () => {
     setMessage("");
     mutate();
   };
+
   return (
     <ChatFooter>
       <input
@@ -252,7 +260,10 @@ const ChatFooterForm: React.FC = () => {
         type={"text"}
         value={message}
         onChange={handleMessageChange}
-        placeholder={"대화를 나눠보세요."}
+        placeholder={
+          isDiaryDeleted ? "삭제된 다이어리 입니다." : "대화를 나눠보세요."
+        }
+        disabled={isDiaryDeleted}
       />
       <button onClick={handleSendMessage}>
         <img src={sendBtn} alt={"message_send_button"} />

--- a/src/types/chattingType.ts
+++ b/src/types/chattingType.ts
@@ -18,8 +18,10 @@ export interface MessageListType {
   userProfileImg: null | string;
 }
 
-// export interface MessageType {
-//   chatMessageList: MessageListType[];
-//   hasNext: boolean;
-//   hasPrevious: boolean;
-// }
+export interface MessageType {
+  chatMessageList: MessageListType[];
+  hasNext: boolean;
+  hasPrevious: boolean;
+  page: number;
+  isDiaryDeleted: boolean;
+}


### PR DESCRIPTION
[JD-153]Refactor: 삭제된 다이어리는 채팅방에서 채팅 내역만 보여주고 입력 막고 채팅 보내지 못하게 하기

[JD-153]: https://ttokttak.atlassian.net/browse/JD-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ